### PR TITLE
Bump version + update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ If you're upgrading packages, ensure you run `yarn install` before committing.
 
 This repo uses classic Yarn i.e. versions 1.x.
 
+Make sure you bump the version in pacakge.json prior to merging to master.
+
 Once your changes have been merged into master, push a new tag to the repo and create a new release.
 
 The release will initiate a github action run to publish the new version to npmjs.com.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/info-provider",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "info-provider",
   "license": "MIT",
   "repository": "https://github.com/hmcts/nodejs-info-provider",


### PR DESCRIPTION
Missed bumping the version before tagging 1.2.4 so doing that now and adding a reminder to the README.